### PR TITLE
Switch to @colors/colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.4",
       "license": "ISC",
       "dependencies": {
-        "chalk": "~4.1.2",
         "commander": "~9.1.0",
         "fs-extra": "~10.0.1",
         "inquirer": "~8.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.4",
       "license": "ISC",
       "dependencies": {
+        "@colors/colors": "~1.5.0",
         "commander": "~9.1.0",
         "fs-extra": "~10.0.1",
         "inquirer": "~8.2.2",
@@ -150,6 +151,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@commitlint/cli": {
@@ -5540,6 +5549,11 @@
           }
         }
       }
+    },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "@commitlint/cli": {
       "version": "16.2.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "homepage": "https://github.com/gpsystem/create-geofs-plugin#readme",
   "dependencies": {
+    "@colors/colors": "~1.5.0",
     "commander": "~9.1.0",
     "fs-extra": "~10.0.1",
     "inquirer": "~8.2.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "homepage": "https://github.com/gpsystem/create-geofs-plugin#readme",
   "dependencies": {
-    "chalk": "~4.1.2",
     "commander": "~9.1.0",
     "fs-extra": "~10.0.1",
     "inquirer": "~8.2.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ const config = {
   },
   plugins: [typescript(), json()],
   external: [
-    "chalk",
+    "@colors/colors/safe",
     "commander",
     "fs-extra",
     "inquirer",

--- a/src/chalkTypes.ts
+++ b/src/chalkTypes.ts
@@ -1,7 +1,0 @@
-import chalk from "chalk";
-
-export const green = chalk.green;
-export const blue = chalk.blue;
-export const red = chalk.red;
-export const yellow = chalk.yellow;
-export const bold = chalk.bold;

--- a/src/config/getMissingConfig/getQuestions.ts
+++ b/src/config/getMissingConfig/getQuestions.ts
@@ -1,4 +1,4 @@
-import { blue, red } from "../../chalkTypes";
+import { blue, red } from "@colors/colors/safe";
 import type { DirectConfig, QuestionI, Template } from "../../types";
 import { isNil, kebabCase } from "lodash";
 import type { Answers } from "inquirer";

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,4 @@
-import { blue, yellow } from "../chalkTypes";
+import { blue, yellow } from "@colors/colors/safe";
 import type { Config, InitialConfig, Template } from "../types";
 import { isAbsolute, resolve } from "node:path";
 import { Command } from "commander";

--- a/src/git/index.ts
+++ b/src/git/index.ts
@@ -1,4 +1,4 @@
-import { green, red, yellow } from "../chalkTypes";
+import { green, red, yellow } from "@colors/colors/safe";
 import isGitInstalled from "./isGitInstalled";
 import { join } from "node:path";
 import { rm } from "node:fs/promises";

--- a/src/git/isGitInstalled.ts
+++ b/src/git/isGitInstalled.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { yellow } from "../chalkTypes";
+import { yellow } from "@colors/colors/safe";
 
 /**
  * Checks if git is installed and accessible by `git` in the shell.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import getConfig from "./config";
 import gitInit from "./git";
 import installPackages from "./npmHandlers";
 import printSuccess from "./printSuccess";
-import { red } from "./chalkTypes";
+import { red } from "@colors/colors/safe";
 import scaffold from "./scaffolding";
 
 export async function start(argv: string[]): Promise<void> {

--- a/src/npmHandlers/NpmError.ts
+++ b/src/npmHandlers/NpmError.ts
@@ -1,4 +1,4 @@
-import { bold } from "../chalkTypes";
+import { bold } from "@colors/colors/safe";
 
 export default function NpmError(msg: string, command: string): Error {
   return new Error(`

--- a/src/printSuccess.ts
+++ b/src/printSuccess.ts
@@ -1,4 +1,4 @@
-import { blue, green } from "./chalkTypes";
+import { blue, green } from "@colors/colors/safe";
 import { join, relative } from "node:path";
 import type { Config } from "./types";
 import { cwd } from "node:process";

--- a/src/scaffolding/index.ts
+++ b/src/scaffolding/index.ts
@@ -1,4 +1,4 @@
-import { green, yellow } from "../chalkTypes";
+import { green, yellow } from "@colors/colors/safe";
 import { mkdtemp, rmSync } from "fs-extra";
 import type { Config } from "../types";
 import copyToFinalDir from "./copyToFinalDir";


### PR DESCRIPTION
This PR switches away from the unmaintained chalk v4 to @colors/colors, which is the community fork of colors.js. See #95 for more details.

Closes #95.