### PR TITLE
Copy files to temp dir correctly on Ubuntu machines

### DIFF
--- a/src/scaffolding/copyToTempDir/index.ts
+++ b/src/scaffolding/copyToTempDir/index.ts
@@ -1,5 +1,5 @@
-import { basename, dirname, join } from "node:path";
-import { mkdir, readFileSync, writeFile } from "fs-extra";
+import { basename, join } from "node:path";
+import { outputFile, readFileSync } from "fs-extra";
 import type { Config } from "../../types";
 import getAllPossibleFiles from "./getAllPossibleFiles";
 import getFilesToCopy from "./getFilesToCopy";
@@ -49,18 +49,8 @@ export default async function copyToTempDir(
         getRelativePathOfFileWhenCopied(file, true)
       );
 
-      // TODO: does this need to be turned into a promise and awaited?
-      mkdir(dirname(fileLocation), { recursive: true }, (err) => {
-        if (err) {
-          // swallow errors where the directory already exists
-          // TODO: is this cross-platform compatible?
-          if (err.code === "EEXIST") return;
-          throw err;
-        }
-      });
-
       // write the rendered data to its new location (see fileLocation)
-      await writeFile(fileLocation, contents, "utf-8");
+      await outputFile(fileLocation, contents, "utf-8");
       copiedFiles.push(fileLocation);
     })
   );


### PR DESCRIPTION
This PR fixes #98 by using fsExtra.outputFile to correctly output files into their respective folders on all machines.